### PR TITLE
Parse environment settings

### DIFF
--- a/src/utilities/MailgunEventsUtility.php
+++ b/src/utilities/MailgunEventsUtility.php
@@ -72,8 +72,8 @@ class MailgunEventsUtility extends Utility
     {
         $pluginSettings = MailgunEvents::$plugin->getSettings();
         $emailSettings = Craft::$app->systemSettings->getSettings('email');
-        $key = $emailSettings['transportSettings']['apiKey'];
-        $domain = $emailSettings['transportSettings']['domain'];
+        $key = Craft::parseEnv($emailSettings['transportSettings']['apiKey']);
+        $domain = Craft::parseEnv($emailSettings['transportSettings']['domain']);
 
         $client = new Mailgun($key);
         $query = [


### PR DESCRIPTION
If environment variables are used for domain or the api key the plugin fails to load any events. 

This just runs those settings through Craft::parseEnv.